### PR TITLE
Adds .tryOrFail() function

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,4 +1,16 @@
-module.exports.RuleError = function () {
-    Error.apply(this, arguments);
-};
-module.exports.RuleError.prototype = Object.create(Error.prototype);
+var _ = require('lodash');
+
+function RuleError () {
+	Error.apply(this, arguments);
+}
+RuleError.prototype = Object.create(Error.prototype);
+
+function ValidationError (response) {
+	this.name = 'ValidationError';
+
+	_.merge(this, response);
+}
+ValidationError.prototype = Object.create(Error.prototype);
+
+module.exports.RuleError = RuleError;
+module.exports.ValidationError = ValidationError;

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,8 @@ var Response = require('./response');
 var Manager = require('./manager');
 var Language = require('./language');
 
+var ValidationError = require('./errors').ValidationError;
+
 // Symbol between the rule name and its parameters in string-type rules.
 var methodDelimiter = ':';
 // Symbol between arguments in rules.
@@ -117,6 +119,23 @@ Validator.prototype.try = function (data, rules) {
     return Bluebird.all(todo)
         .then(function () {
             return response;
+        });
+};
+
+/**
+ * Attempts to run a validation with .try(), throwing a ValidationError on failure.
+ *
+ * @return {Promise}
+ */
+Validator.prototype.tryOrFail = function () {
+    // Apply arguments to .try() and simply throw an exception if it fails
+    return this.try.apply(this, arguments)
+        .then(function (result) {
+            if (result.failed) {
+                throw new ValidationError(result);
+            }
+
+            return result;
         });
 };
 

--- a/spec/E2ESpec.js
+++ b/spec/E2ESpec.js
@@ -12,6 +12,50 @@ describe('everythang', function () {
         };
     });
 
+    describe('tryOrFail', function () {
+        it('passes', function (done) {
+            validator.tryOrFail({
+                username: 'brendanashworth',
+                password: 'secret',
+                acceptTOS: true
+            }, rules).then(function(result) {
+                expect(result.name).toBe(undefined);
+
+                expect(result.passed).toBe(true);
+                expect(result.failed).toBe(false);
+                expect(result.errors).toEqual({});
+
+                done();
+            }).catch(function(err) {
+                this.fail();
+
+                done();
+            });
+        });
+
+        it('fails', function (done) {
+            validator.tryOrFail({
+                username: 'brendanashworth',
+                acceptTOS: false
+            }, rules).then(function(result) {
+                this.fail();
+
+                done();
+            }).catch(function(err) {
+                expect(err.name).toEqual('ValidationError');
+
+                expect(err.passed).toBe(false);
+                expect(err.failed).toBe(true);
+                expect(err.errors).toEqual({
+                    password: [ 'The password is required.' ],
+                    acceptTOS: [ 'The acceptTOS must be a boolean.' ]
+                });
+
+                done();
+            });
+        })
+    });
+
     it('passses', function (done) {
         validator.try({
             username: 'connor4312',


### PR DESCRIPTION
Adds a function that, instead of continuing in the promise chain
on a failed validation, throws a ValidationError with the expected
errors.